### PR TITLE
Support for multiple magnetometers

### DIFF
--- a/src/dsbase/sensors/magnetometer.c
+++ b/src/dsbase/sensors/magnetometer.c
@@ -11,23 +11,19 @@
 #define MAX_BUFF_SIZE   0x25
 
 // TODO:  Need some const decorations
-FILE_STATIC uint8_t szBuff;
 FILE_STATIC uint8_t i2cBuff[MAX_BUFF_SIZE];
-FILE_STATIC hDev hSensor;
 
-MagnetometerData mdata;
-
-void magInit(bus_instance_i2c bus)
+hDev magInit(bus_instance_i2c bus)
 {
     i2cEnable(bus);
-    hSensor = i2cInit(bus, MAG_I2C_7BIT_ADDRESS);
+    hDev hSensor = i2cInit(bus, MAG_I2C_7BIT_ADDRESS);
 
 #if defined(__BSP_HW_MAGTOM_HMC5883L__)  /* */
 
     // HMC5883 pattern is to address
 
-   // selfTestConfig();
-   normalOperationConfig();
+   // selfTestConfig(hSensor);
+   normalOperationConfig(hSensor);
 
 #elif defined( __BSP_HW_MAGTOM_MAG3110__)
 
@@ -46,9 +42,11 @@ void magInit(bus_instance_i2c bus)
 #error Unknown - or no - magnetometer specified.  Use HW_MAGTOM definition to set type.
 
 #endif  /* HW_MAGTOM */
+
+    return hSensor;
 }
 
-void selfTestConfig()
+void selfTestConfig(hDev hSensor)
 {
     i2cBuff[0] = MAG_HMC5883L_REG_ADDR_CRA;
     i2cBuff[1] = MAG_HMC5883L_CONFIG_REGISTER_A_SELF_TEST;
@@ -58,7 +56,7 @@ void selfTestConfig()
 }
 
 
-void normalOperationConfig()
+void normalOperationConfig(hDev hSensor)
 {
     // HMC5883 pattern is to address
     i2cBuff[0] = MAG_HMC5883L_REG_ADDR_CRA;
@@ -69,9 +67,9 @@ void normalOperationConfig()
     i2cMasterWrite(hSensor, i2cBuff, 4);
 }
 
-MagnetometerData *magReadXYZData(UnitConversionMode desiredConversion)
+void magReadXYZData(hDev hSensor, UnitConversionMode desiredConversion, MagnetometerData *mdata)
 {
-    mdata.conversionMode = desiredConversion;
+    mdata->conversionMode = desiredConversion;
     i2cMasterRegisterRead(hSensor, MAG_XYZ_OUTPUT_REG_ADDR_START, i2cBuff, 6 );
     i2cMasterRegisterRead(hSensor, MAG_HMC5883L_REG_ADDR_TORA, &i2cBuff[6], 2 );
 
@@ -79,18 +77,18 @@ MagnetometerData *magReadXYZData(UnitConversionMode desiredConversion)
 
     // NOTE:  Order of X/Z/Y on HMC5883 is, unfortunately, intentional ...
 
-    mdata.rawX = (int16_t)(i2cBuff[1] | ((int16_t)i2cBuff[0] << 8));
-    mdata.rawZ = (int16_t)(i2cBuff[3] | ((int16_t)i2cBuff[2] << 8));
-    mdata.rawY = (int16_t)(i2cBuff[5] | ((int16_t)i2cBuff[4] << 8));
+    mdata->rawX = (int16_t)(i2cBuff[1] | ((int16_t)i2cBuff[0] << 8));
+    mdata->rawZ = (int16_t)(i2cBuff[3] | ((int16_t)i2cBuff[2] << 8));
+    mdata->rawY = (int16_t)(i2cBuff[5] | ((int16_t)i2cBuff[4] << 8));
 
-    mdata.rawTempA = (int8_t)i2cBuff[6];
-    mdata.rawTempB = (int8_t)i2cBuff[7];
+    mdata->rawTempA = (int8_t)i2cBuff[6];
+    mdata->rawTempB = (int8_t)i2cBuff[7];
 
 #elif defined( __BSP_HW_MAGTOM_MAG3110__)
 
-    mdata.rawX = (int16_t)(i2cBuff[1] | ((int16_t)i2cBuff[0] << 8));
-    mdata.rawY = (int16_t)(i2cBuff[3] | ((int16_t)i2cBuff[2] << 8));
-    mdata.rawZ = (int16_t)(i2cBuff[5] | ((int16_t)i2cBuff[4] << 8));
+    mdata->rawX = (int16_t)(i2cBuff[1] | ((int16_t)i2cBuff[0] << 8));
+    mdata->rawY = (int16_t)(i2cBuff[3] | ((int16_t)i2cBuff[2] << 8));
+    mdata->rawZ = (int16_t)(i2cBuff[5] | ((int16_t)i2cBuff[4] << 8));
 
 #else
 
@@ -118,12 +116,10 @@ MagnetometerData *magReadXYZData(UnitConversionMode desiredConversion)
 
     // (MSB * 2^8 + LSB) / (2^4 * 8) + 25 in C
 
-    mdata.convertedX = mdata.rawX * conversionFactor;
-    mdata.convertedY = mdata.rawY * conversionFactor;
-    mdata.convertedZ = mdata.rawZ * conversionFactor;
-    mdata.convertedTemp = (double)((((double)mdata.rawTempA * 256.0)  +  (double) mdata.rawTempB * 1.0) / (8.0 * 16.0) + 25.0);
-
-    return &mdata;
+    mdata->convertedX = mdata->rawX * conversionFactor;
+    mdata->convertedY = mdata->rawY * conversionFactor;
+    mdata->convertedZ = mdata->rawZ * conversionFactor;
+    mdata->convertedTemp = (double)((((double)mdata->rawTempA * 256.0)  +  (double) mdata->rawTempB * 1.0) / (8.0 * 16.0) + 25.0);
 }
 
 

--- a/src/dsbase/sensors/magnetometer.h
+++ b/src/dsbase/sensors/magnetometer.h
@@ -65,9 +65,9 @@ typedef struct  {
 } MagnetometerData;
 
 // Main entry points
-void magInit();
-MagnetometerData *magReadXYZData(UnitConversionMode);
-void selfTestConfig();
-void normalOperationConfig();
+hDev magInit(bus_instance_i2c bus);
+void magReadXYZData(hDev handle, UnitConversionMode mode, MagnetometerData *output);
+void selfTestConfig(hDev handle);
+void normalOperationConfig(hDev handle);
 
 #endif /* MAGNETOMETER_H_ */

--- a/src/dsbase/sensors/magnetometer.h
+++ b/src/dsbase/sensors/magnetometer.h
@@ -46,6 +46,7 @@
 typedef enum _unitConversionMode {
     ConvertToNanoTeslas,
     ConvertToTeslas,
+    ConvertToNone, // skip conversions
 } UnitConversionMode;
 
 // Raw values are magnetometer-dependent
@@ -64,10 +65,18 @@ typedef struct  {
     double convertedTemp;
 } MagnetometerData;
 
-// Main entry points
-hDev magInit(bus_instance_i2c bus);
-void magReadXYZData(hDev handle, UnitConversionMode mode, MagnetometerData *output);
-void selfTestConfig(hDev handle);
-void normalOperationConfig(hDev handle);
+typedef uint8_t hMag;
+
+/*
+ * Initializes a magnetometer on a specific I2C bus.
+ * Initialize no more than one per bus.
+ *
+ * Returns the magnetometer's handle to be passed to other mag. functions
+ */
+hMag magInit(bus_instance_i2c bus);
+
+MagnetometerData *magReadXYZData(hMag handle, UnitConversionMode mode);
+void selfTestConfig(hMag handle);
+void normalOperationConfig(hMag handle);
 
 #endif /* MAGNETOMETER_H_ */

--- a/src/ssmods/ss_ADCS_SENSORPROC/adcs_sensorproc_ids.h
+++ b/src/ssmods/ss_ADCS_SENSORPROC/adcs_sensorproc_ids.h
@@ -13,7 +13,8 @@
 // COSMOS telemetry IDs
 #define TLM_ID_SUNSENSOR  121
 #define TLM_ID_PHOTODIODE 118
-#define TLM_ID_MAG        117
+#define TLM_ID_MAG1       117
+#define TLM_ID_MAG2       115
 #define TLM_ID_IMU        116
 
 #define TLM_ID_GPSHEALTH  120

--- a/src/ssmods/ss_ADCS_SENSORPROC/adcs_sensorproc_main.c
+++ b/src/ssmods/ss_ADCS_SENSORPROC/adcs_sensorproc_main.c
@@ -1,7 +1,8 @@
 #define ENABLE_GPS         0
 #define ENABLE_PHOTODIODES 0
 #define ENABLE_SUNSENSOR   1
-#define ENABLE_MAG         1
+#define ENABLE_MAG1        1
+#define ENABLE_MAG2        1
 #define ENABLE_IMU         1
 
 #include <adcs_sensorproc.h>
@@ -78,10 +79,19 @@ FILE_STATIC const SensorInterface sensorInterfaces[] =
      NULL,
     },
 #endif
-#if ENABLE_MAG
+#if ENABLE_MAG1
     {
-     magioInit,
-     magioUpdate,
+     magioInit1,
+     magioUpdate1,
+     UpdateRate_5Hz,
+     NULL,
+     NULL,
+    },
+#endif
+#if ENABLE_MAG2
+    {
+     magioInit2,
+     magioUpdate2,
      UpdateRate_5Hz,
      NULL,
      NULL,

--- a/src/ssmods/ss_ADCS_SENSORPROC/mag_io.c
+++ b/src/ssmods/ss_ADCS_SENSORPROC/mag_io.c
@@ -12,23 +12,48 @@
 #include "core/i2c.h"
 #include "core/utils.h"
 
-void magioInit()
+FILE_STATIC hDev mag1;
+FILE_STATIC hDev mag2;
+
+FILE_STATIC hDev magioInit(bus_instance_i2c bus)
 {
-    magInit(MAG_I2CBUS);
-    normalOperationConfig();
+    hDev handle = magInit(bus);
+    normalOperationConfig(bus);
+    return handle;
 }
 
-void magioUpdate()
+void magioInit1()
 {
-    MagnetometerData *data = magReadXYZData(ConvertToNanoTeslas);
+    mag1 = magioInit(MAG1_I2CBUS);
+}
+
+void magioInit2()
+{
+    mag2 = magioInit(MAG2_I2CBUS);
+}
+
+FILE_STATIC void magioUpdate(hDev handle, uint8_t tlmId)
+{
+    MagnetometerData data;
+    magReadXYZData(handle, ConvertToNanoTeslas, &data);
 
     // send backchannel data
     mag_segment seg;
-    seg.x = data->rawX;
-    seg.y = data->rawY;
-    seg.z = data->rawZ;
-    bcbinPopulateHeader(&seg.header, TLM_ID_MAG, sizeof(seg));
+    seg.x = data.rawX;
+    seg.y = data.rawY;
+    seg.z = data.rawZ;
+    bcbinPopulateHeader(&seg.header, tlmId, sizeof(seg));
     bcbinSendPacket((uint8_t *) &seg, sizeof(seg));
 
     // TODO send CAN data
+}
+
+void magioUpdate1()
+{
+    magioUpdate(mag1, TLM_ID_MAG1);
+}
+
+void magioUpdate2()
+{
+    magioUpdate(mag2, TLM_ID_MAG2);
 }

--- a/src/ssmods/ss_ADCS_SENSORPROC/mag_io.c
+++ b/src/ssmods/ss_ADCS_SENSORPROC/mag_io.c
@@ -12,13 +12,13 @@
 #include "core/i2c.h"
 #include "core/utils.h"
 
-FILE_STATIC hDev mag1;
-FILE_STATIC hDev mag2;
+FILE_STATIC hMag mag1;
+FILE_STATIC hMag mag2;
 
-FILE_STATIC hDev magioInit(bus_instance_i2c bus)
+FILE_STATIC hMag magioInit(bus_instance_i2c bus)
 {
-    hDev handle = magInit(bus);
-    normalOperationConfig(bus);
+    hMag handle = magInit(bus);
+    normalOperationConfig(handle);
     return handle;
 }
 
@@ -32,16 +32,15 @@ void magioInit2()
     mag2 = magioInit(MAG2_I2CBUS);
 }
 
-FILE_STATIC void magioUpdate(hDev handle, uint8_t tlmId)
+FILE_STATIC void magioUpdate(hMag handle, uint8_t tlmId)
 {
-    MagnetometerData data;
-    magReadXYZData(handle, ConvertToNanoTeslas, &data);
+    MagnetometerData *data = magReadXYZData(handle, ConvertToNone);
 
     // send backchannel data
     mag_segment seg;
-    seg.x = data.rawX;
-    seg.y = data.rawY;
-    seg.z = data.rawZ;
+    seg.x = data->rawX;
+    seg.y = data->rawY;
+    seg.z = data->rawZ;
     bcbinPopulateHeader(&seg.header, tlmId, sizeof(seg));
     bcbinSendPacket((uint8_t *) &seg, sizeof(seg));
 

--- a/src/ssmods/ss_ADCS_SENSORPROC/mag_io.h
+++ b/src/ssmods/ss_ADCS_SENSORPROC/mag_io.h
@@ -10,8 +10,8 @@
 
 #define DELAY_MAG_UPDATE_MS 200
 
-// TODO confirm this bus after descope board redesign
-#define MAG_I2CBUS I2CBus1
+#define MAG1_I2CBUS I2CBus1
+#define MAG2_I2CBUS I2CBus2
 
 #include "core/debugtools.h"
 
@@ -24,7 +24,9 @@ TLM_SEGMENT {
     int16_t z;
 } mag_segment;
 
-void magioInit();
-void magioUpdate();
+void magioInit1();
+void magioInit2();
+void magioUpdate1();
+void magioUpdate2();
 
 #endif /* MAG_IO_H_ */


### PR DESCRIPTION
The magnetometer wrapper needs to change to support multiple magnetometers for the sensor processing board. Magnetometer functions now require a handle parameter. This breaks bdot code.

I also added an option to skip conversions and leave the converted values uninitialized in the data struct.