### PR TITLE
Add mag2 CAN packet Also fixed RC_EPS_BATT

### DIFF
--- a/src/dsbase/interfaces/canwrap.c
+++ b/src/dsbase/interfaces/canwrap.c
@@ -205,6 +205,27 @@ void setCANPacketRxCallback(void (*ReceiveCallbackArg)(CANPacket *packet)) {
 
 // AUTOGEN STUFF HERE
 
+void decoderc_eps_batt_7(CANPacket *input, rc_eps_batt_7 *output){
+    uint64_t *thePointer = (uint64_t *) input -> data;
+    reverseArray(input -> data, 0, 7);
+    const uint64_t fullData = *thePointer;
+    output -> rc_eps_batt_7_acc_charge_min = (uint16_t) (((fullData & ((uint64_t) 0xffff << 48)) >> 48));
+    output -> rc_eps_batt_7_acc_charge_max = (uint16_t) (((fullData & ((uint64_t) 0xffff << 32)) >> 32));
+    output -> rc_eps_batt_7_acc_charge_avg = (uint16_t) (((fullData & ((uint64_t) 0xffff << 16)) >> 16));
+}
+
+void encoderc_eps_batt_7(rc_eps_batt_7 *input, CANPacket *output){
+    output -> id = 304677466;
+    output -> length = 6;
+    uint64_t fullPacketData = 0x0000000000000000;
+    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_7_acc_charge_min))) & 0xffff) << 48;
+    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_7_acc_charge_max))) & 0xffff) << 32;
+    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_7_acc_charge_avg))) & 0xffff) << 16;
+    uint64_t *thePointer = (uint64_t *) (&(output -> data));
+    *thePointer = fullPacketData;
+    reverseArray((output->data), 0, 7);
+}
+
 void decoderc_adcs_estim_14(CANPacket *input, rc_adcs_estim_14 *output){
     uint64_t *thePointer = (uint64_t *) input -> data;
     reverseArray(input -> data, 0, 7);
@@ -2190,20 +2211,18 @@ void decoderc_eps_batt_6(CANPacket *input, rc_eps_batt_6 *output){
     uint64_t *thePointer = (uint64_t *) input -> data;
     reverseArray(input -> data, 0, 7);
     const uint64_t fullData = *thePointer;
-    output -> rc_eps_batt_6_soc_min = (uint8_t) (((fullData & ((uint64_t) 0xff << 56)) >> 56));
-    output -> rc_eps_batt_6_soc_max = (uint8_t) (((fullData & ((uint64_t) 0xff << 48)) >> 48));
-    output -> rc_eps_batt_6_soc_avg = (uint8_t) (((fullData & ((uint64_t) 0xff << 40)) >> 40));
-    output -> rc_eps_batt_6_last_charge = (uint64_t) (((fullData & ((uint64_t) 0xffffffffff))));
+    output -> rc_eps_batt_6_status = (uint8_t) (((fullData & ((uint64_t) 0xff << 56)) >> 56));
+    output -> rc_eps_batt_6_ctrl = (uint8_t) (((fullData & ((uint64_t) 0xff << 48)) >> 48));
+    output -> rc_eps_batt_6_last_charge = (uint64_t) (((fullData & ((uint64_t) 0xffffffffff << 8)) >> 8));
 }
 
 void encoderc_eps_batt_6(rc_eps_batt_6 *input, CANPacket *output){
     output -> id = 304677381;
-    output -> length = 8;
+    output -> length = 7;
     uint64_t fullPacketData = 0x0000000000000000;
-    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_6_soc_min))) & 0xff) << 56;
-    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_6_soc_max))) & 0xff) << 48;
-    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_6_soc_avg))) & 0xff) << 40;
-    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_6_last_charge))) & 0xffffffffff);
+    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_6_status))) & 0xff) << 56;
+    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_6_ctrl))) & 0xff) << 48;
+    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_6_last_charge))) & 0xffffffffff) << 8;
     uint64_t *thePointer = (uint64_t *) (&(output -> data));
     *thePointer = fullPacketData;
     reverseArray((output->data), 0, 7);

--- a/src/dsbase/interfaces/canwrap.c
+++ b/src/dsbase/interfaces/canwrap.c
@@ -205,6 +205,120 @@ void setCANPacketRxCallback(void (*ReceiveCallbackArg)(CANPacket *packet)) {
 
 // AUTOGEN STUFF HERE
 
+void decoderc_adcs_estim_14(CANPacket *input, rc_adcs_estim_14 *output){
+    uint64_t *thePointer = (uint64_t *) input -> data;
+    reverseArray(input -> data, 0, 7);
+    const uint64_t fullData = *thePointer;
+    uint64_t temprc_adcs_estim_14_mag_z = (uint64_t) ((fullData & ((uint64_t) 0xffffffffffffffff)));
+output -> rc_adcs_estim_14_mag_z = (*((double *)(&(temprc_adcs_estim_14_mag_z))));
+}
+
+void encoderc_adcs_estim_14(rc_adcs_estim_14 *input, CANPacket *output){
+    output -> id = 304677465;
+    output -> length = 8;
+    uint64_t fullPacketData = 0x0000000000000000;
+    const double temprc_adcs_estim_14_mag_z = ((input -> rc_adcs_estim_14_mag_z));
+    fullPacketData |= ((uint64_t)(*((uint64_t *)(&(temprc_adcs_estim_14_mag_z)))));
+    uint64_t *thePointer = (uint64_t *) (&(output -> data));
+    *thePointer = fullPacketData;
+    reverseArray((output->data), 0, 7);
+}
+
+void decoderc_adcs_estim_13(CANPacket *input, rc_adcs_estim_13 *output){
+    uint64_t *thePointer = (uint64_t *) input -> data;
+    reverseArray(input -> data, 0, 7);
+    const uint64_t fullData = *thePointer;
+    uint64_t temprc_adcs_estim_13_mag_y = (uint64_t) ((fullData & ((uint64_t) 0xffffffffffffffff)));
+output -> rc_adcs_estim_13_mag_y = (*((double *)(&(temprc_adcs_estim_13_mag_y))));
+}
+
+void encoderc_adcs_estim_13(rc_adcs_estim_13 *input, CANPacket *output){
+    output -> id = 304677464;
+    output -> length = 8;
+    uint64_t fullPacketData = 0x0000000000000000;
+    const double temprc_adcs_estim_13_mag_y = ((input -> rc_adcs_estim_13_mag_y));
+    fullPacketData |= ((uint64_t)(*((uint64_t *)(&(temprc_adcs_estim_13_mag_y)))));
+    uint64_t *thePointer = (uint64_t *) (&(output -> data));
+    *thePointer = fullPacketData;
+    reverseArray((output->data), 0, 7);
+}
+
+void decoderc_adcs_estim_12(CANPacket *input, rc_adcs_estim_12 *output){
+    uint64_t *thePointer = (uint64_t *) input -> data;
+    reverseArray(input -> data, 0, 7);
+    const uint64_t fullData = *thePointer;
+    uint64_t temprc_adcs_estim_12_mag_x = (uint64_t) ((fullData & ((uint64_t) 0xffffffffffffffff)));
+output -> rc_adcs_estim_12_mag_x = (*((double *)(&(temprc_adcs_estim_12_mag_x))));
+}
+
+void encoderc_adcs_estim_12(rc_adcs_estim_12 *input, CANPacket *output){
+    output -> id = 304677463;
+    output -> length = 8;
+    uint64_t fullPacketData = 0x0000000000000000;
+    const double temprc_adcs_estim_12_mag_x = ((input -> rc_adcs_estim_12_mag_x));
+    fullPacketData |= ((uint64_t)(*((uint64_t *)(&(temprc_adcs_estim_12_mag_x)))));
+    uint64_t *thePointer = (uint64_t *) (&(output -> data));
+    *thePointer = fullPacketData;
+    reverseArray((output->data), 0, 7);
+}
+
+void decoderc_adcs_estim_11(CANPacket *input, rc_adcs_estim_11 *output){
+    uint64_t *thePointer = (uint64_t *) input -> data;
+    reverseArray(input -> data, 0, 7);
+    const uint64_t fullData = *thePointer;
+    uint64_t temprc_adcs_estim_11_sun_z = (uint64_t) ((fullData & ((uint64_t) 0xffffffffffffffff)));
+output -> rc_adcs_estim_11_sun_z = (*((double *)(&(temprc_adcs_estim_11_sun_z))));
+}
+
+void encoderc_adcs_estim_11(rc_adcs_estim_11 *input, CANPacket *output){
+    output -> id = 304677462;
+    output -> length = 8;
+    uint64_t fullPacketData = 0x0000000000000000;
+    const double temprc_adcs_estim_11_sun_z = ((input -> rc_adcs_estim_11_sun_z));
+    fullPacketData |= ((uint64_t)(*((uint64_t *)(&(temprc_adcs_estim_11_sun_z)))));
+    uint64_t *thePointer = (uint64_t *) (&(output -> data));
+    *thePointer = fullPacketData;
+    reverseArray((output->data), 0, 7);
+}
+
+void decoderc_adcs_estim_10(CANPacket *input, rc_adcs_estim_10 *output){
+    uint64_t *thePointer = (uint64_t *) input -> data;
+    reverseArray(input -> data, 0, 7);
+    const uint64_t fullData = *thePointer;
+    uint64_t temprc_adcs_estim_10_sun_y = (uint64_t) ((fullData & ((uint64_t) 0xffffffffffffffff)));
+output -> rc_adcs_estim_10_sun_y = (*((double *)(&(temprc_adcs_estim_10_sun_y))));
+}
+
+void encoderc_adcs_estim_10(rc_adcs_estim_10 *input, CANPacket *output){
+    output -> id = 304677461;
+    output -> length = 8;
+    uint64_t fullPacketData = 0x0000000000000000;
+    const double temprc_adcs_estim_10_sun_y = ((input -> rc_adcs_estim_10_sun_y));
+    fullPacketData |= ((uint64_t)(*((uint64_t *)(&(temprc_adcs_estim_10_sun_y)))));
+    uint64_t *thePointer = (uint64_t *) (&(output -> data));
+    *thePointer = fullPacketData;
+    reverseArray((output->data), 0, 7);
+}
+
+void decoderc_adcs_estim_9(CANPacket *input, rc_adcs_estim_9 *output){
+    uint64_t *thePointer = (uint64_t *) input -> data;
+    reverseArray(input -> data, 0, 7);
+    const uint64_t fullData = *thePointer;
+    uint64_t temprc_adcs_estim_9_sun_x = (uint64_t) ((fullData & ((uint64_t) 0xffffffffffffffff)));
+output -> rc_adcs_estim_9_sun_x = (*((double *)(&(temprc_adcs_estim_9_sun_x))));
+}
+
+void encoderc_adcs_estim_9(rc_adcs_estim_9 *input, CANPacket *output){
+    output -> id = 304677460;
+    output -> length = 8;
+    uint64_t fullPacketData = 0x0000000000000000;
+    const double temprc_adcs_estim_9_sun_x = ((input -> rc_adcs_estim_9_sun_x));
+    fullPacketData |= ((uint64_t)(*((uint64_t *)(&(temprc_adcs_estim_9_sun_x)))));
+    uint64_t *thePointer = (uint64_t *) (&(output -> data));
+    *thePointer = fullPacketData;
+    reverseArray((output->data), 0, 7);
+}
+
 void decoderc_eps_dist_16(CANPacket *input, rc_eps_dist_16 *output){
     uint64_t *thePointer = (uint64_t *) input -> data;
     reverseArray(input -> data, 0, 7);

--- a/src/dsbase/interfaces/canwrap.h
+++ b/src/dsbase/interfaces/canwrap.h
@@ -26,6 +26,12 @@
 
 // BEGIN GENERATOR MACROS
 
+#define CAN_ID_RC_ADCS_ESTIM_14 304677465
+#define CAN_ID_RC_ADCS_ESTIM_13 304677464
+#define CAN_ID_RC_ADCS_ESTIM_12 304677463
+#define CAN_ID_RC_ADCS_ESTIM_11 304677462
+#define CAN_ID_RC_ADCS_ESTIM_10 304677461
+#define CAN_ID_RC_ADCS_ESTIM_9 304677460
 #define CAN_ID_RC_EPS_DIST_16 304677458
 #define CAN_ID_RC_EPS_DIST_9 304677451
 #define CAN_ID_RC_EPS_DIST_7 304677449
@@ -232,6 +238,30 @@ void (*CANPacketReceived)(CANPacket *);
 uint8_t canSendPacket(CANPacket *packet);
 
 void setCANPacketRxCallback(void (*ReceiveCallbackArg)(CANPacket *packet));
+typedef struct rc_adcs_estim_14 {
+    double rc_adcs_estim_14_mag_z; //  (No Units)
+} rc_adcs_estim_14;
+
+typedef struct rc_adcs_estim_13 {
+    double rc_adcs_estim_13_mag_y; //  (No Units)
+} rc_adcs_estim_13;
+
+typedef struct rc_adcs_estim_12 {
+    double rc_adcs_estim_12_mag_x; //  (No Units)
+} rc_adcs_estim_12;
+
+typedef struct rc_adcs_estim_11 {
+    double rc_adcs_estim_11_sun_z; //  (No Units)
+} rc_adcs_estim_11;
+
+typedef struct rc_adcs_estim_10 {
+    double rc_adcs_estim_10_sun_y; //  (No Units)
+} rc_adcs_estim_10;
+
+typedef struct rc_adcs_estim_9 {
+    double rc_adcs_estim_9_sun_x; //  (No Units)
+} rc_adcs_estim_9;
+
 typedef struct rc_eps_dist_16 {
     uint8_t rc_eps_dist_16_ppt_state; //  (No Units)
     uint16_t rc_eps_dist_16_ppt_c_min; // mA
@@ -1036,6 +1066,24 @@ typedef struct grnd_epoch {
     uint8_t grnd_epoch_val_overflow; //  (No Units)
     uint32_t grnd_epoch_val; // 2^-8 s
 } grnd_epoch;
+
+void encoderc_adcs_estim_14(rc_adcs_estim_14 *input, CANPacket* output);
+void decoderc_adcs_estim_14(CANPacket *input, rc_adcs_estim_14 *output);
+
+void encoderc_adcs_estim_13(rc_adcs_estim_13 *input, CANPacket* output);
+void decoderc_adcs_estim_13(CANPacket *input, rc_adcs_estim_13 *output);
+
+void encoderc_adcs_estim_12(rc_adcs_estim_12 *input, CANPacket* output);
+void decoderc_adcs_estim_12(CANPacket *input, rc_adcs_estim_12 *output);
+
+void encoderc_adcs_estim_11(rc_adcs_estim_11 *input, CANPacket* output);
+void decoderc_adcs_estim_11(CANPacket *input, rc_adcs_estim_11 *output);
+
+void encoderc_adcs_estim_10(rc_adcs_estim_10 *input, CANPacket* output);
+void decoderc_adcs_estim_10(CANPacket *input, rc_adcs_estim_10 *output);
+
+void encoderc_adcs_estim_9(rc_adcs_estim_9 *input, CANPacket* output);
+void decoderc_adcs_estim_9(CANPacket *input, rc_adcs_estim_9 *output);
 
 void encoderc_eps_dist_16(rc_eps_dist_16 *input, CANPacket* output);
 void decoderc_eps_dist_16(CANPacket *input, rc_eps_dist_16 *output);

--- a/src/dsbase/interfaces/canwrap.h
+++ b/src/dsbase/interfaces/canwrap.h
@@ -26,6 +26,7 @@
 
 // BEGIN GENERATOR MACROS
 
+#define CAN_ID_RC_EPS_BATT_7 304677466
 #define CAN_ID_RC_ADCS_ESTIM_14 304677465
 #define CAN_ID_RC_ADCS_ESTIM_13 304677464
 #define CAN_ID_RC_ADCS_ESTIM_12 304677463
@@ -238,6 +239,12 @@ void (*CANPacketReceived)(CANPacket *);
 uint8_t canSendPacket(CANPacket *packet);
 
 void setCANPacketRxCallback(void (*ReceiveCallbackArg)(CANPacket *packet));
+typedef struct rc_eps_batt_7 {
+    uint16_t rc_eps_batt_7_acc_charge_min; // 22.588 mAh
+    uint16_t rc_eps_batt_7_acc_charge_max; // 22.588 mAh
+    uint16_t rc_eps_batt_7_acc_charge_avg; // 22.588 mAh
+} rc_eps_batt_7;
+
 typedef struct rc_adcs_estim_14 {
     double rc_adcs_estim_14_mag_z; //  (No Units)
 } rc_adcs_estim_14;
@@ -789,9 +796,8 @@ typedef struct rc_eps_gen_1 {
 } rc_eps_gen_1;
 
 typedef struct rc_eps_batt_6 {
-    uint8_t rc_eps_batt_6_soc_min; // pct
-    uint8_t rc_eps_batt_6_soc_max; // pct
-    uint8_t rc_eps_batt_6_soc_avg; // pct
+    uint8_t rc_eps_batt_6_status; //  (No Units)
+    uint8_t rc_eps_batt_6_ctrl; //  (No Units)
     uint64_t rc_eps_batt_6_last_charge; // 2^-8 seconds
 } rc_eps_batt_6;
 
@@ -1066,6 +1072,9 @@ typedef struct grnd_epoch {
     uint8_t grnd_epoch_val_overflow; //  (No Units)
     uint32_t grnd_epoch_val; // 2^-8 s
 } grnd_epoch;
+
+void encoderc_eps_batt_7(rc_eps_batt_7 *input, CANPacket* output);
+void decoderc_eps_batt_7(CANPacket *input, rc_eps_batt_7 *output);
 
 void encoderc_adcs_estim_14(rc_adcs_estim_14 *input, CANPacket* output);
 void decoderc_adcs_estim_14(CANPacket *input, rc_adcs_estim_14 *output);

--- a/teams/cdh/CAN/CANDB-MASTER-DS1.dbc
+++ b/teams/cdh/CAN/CANDB-MASTER-DS1.dbc
@@ -46,6 +46,24 @@ VAL_TABLE_ agg 5 "sum" 4 "max" 3 "min" 2 "count" 1 "avg" 0 "none" ;
 VAL_TABLE_ bool 1 "true" 0 "false" ;
 
 
+BO_ 2452161113 rc_adcs_estim_14: 8 Vector__XXX
+ SG_ rc_adcs_estim_14_mag_z : 0|64@1- (1,0) [-1|1] "" Vector__XXX
+
+BO_ 2452161112 rc_adcs_estim_13: 8 Vector__XXX
+ SG_ rc_adcs_estim_13_mag_y : 0|64@1- (1,0) [-1|1] "" Vector__XXX
+
+BO_ 2452161111 rc_adcs_estim_12: 8 Vector__XXX
+ SG_ rc_adcs_estim_12_mag_x : 0|64@1- (1,0) [-1|1] "" Vector__XXX
+
+BO_ 2452161110 rc_adcs_estim_11: 8 Vector__XXX
+ SG_ rc_adcs_estim_11_sun_z : 0|64@1- (1,0) [-1|1] "" Vector__XXX
+
+BO_ 2452161109 rc_adcs_estim_10: 8 Vector__XXX
+ SG_ rc_adcs_estim_10_sun_y : 0|64@1- (1,0) [-1|1] "" Vector__XXX
+
+BO_ 2452161108 rc_adcs_estim_9: 8 Vector__XXX
+ SG_ rc_adcs_estim_9_sun_x : 0|64@1- (1,0) [-1|1] "" Vector__XXX
+
 BO_ 2452161106 rc_eps_dist_16: 7 Vector__XXX
  SG_ rc_eps_dist_16_ppt_state : 0|8@1+ (1,0) [0|3] "" Vector__XXX
  SG_ rc_eps_dist_16_ppt_c_min : 8|16@1+ (1,0) [0|65535] "mA" Vector__XXX
@@ -770,6 +788,12 @@ VAL_ 2183266498 eps_batt_state_bal 1 "true" 0 "false" ;
 VAL_ 2183266498 eps_batt_state_heat 1 "true" 0 "false" ;
 VAL_ 2483355713 sensorproc_sun_valid 1 "true" 0 "false" ;
 VAL_ 2181496864 bdot_tumble_status_status 1 "true" 0 "false" ;
+SIG_VALTYPE_ 2452161113 rc_adcs_estim_14_mag_z : 2;
+SIG_VALTYPE_ 2452161112 rc_adcs_estim_13_mag_y : 2;
+SIG_VALTYPE_ 2452161111 rc_adcs_estim_12_mag_x : 2;
+SIG_VALTYPE_ 2452161110 rc_adcs_estim_11_sun_z : 2;
+SIG_VALTYPE_ 2452161109 rc_adcs_estim_10_sun_y : 2;
+SIG_VALTYPE_ 2452161108 rc_adcs_estim_9_sun_x : 2;
 SIG_VALTYPE_ 2452161086 rc_adcs_mpc_11_omega_y_avg : 2;
 SIG_VALTYPE_ 2452161082 rc_adcs_mpc_7_omega_x_max : 2;
 SIG_VALTYPE_ 2452161083 rc_adcs_mpc_8_omega_x_avg : 2;

--- a/teams/cdh/CAN/CANDB-MASTER-DS1.dbc
+++ b/teams/cdh/CAN/CANDB-MASTER-DS1.dbc
@@ -46,6 +46,11 @@ VAL_TABLE_ agg 5 "sum" 4 "max" 3 "min" 2 "count" 1 "avg" 0 "none" ;
 VAL_TABLE_ bool 1 "true" 0 "false" ;
 
 
+BO_ 2452161114 rc_eps_batt_7: 6 Vector__XXX
+ SG_ rc_eps_batt_7_acc_charge_min : 0|16@1+ (1,0) [0|65535] "22.588 mAh" Vector__XXX
+ SG_ rc_eps_batt_7_acc_charge_max : 16|16@1+ (1,0) [0|65535] "22.588 mAh" Vector__XXX
+ SG_ rc_eps_batt_7_acc_charge_avg : 32|16@1+ (1,0) [0|65535] "22.588 mAh" Vector__XXX
+
 BO_ 2452161113 rc_adcs_estim_14: 8 Vector__XXX
  SG_ rc_adcs_estim_14_mag_z : 0|64@1- (1,0) [-1|1] "" Vector__XXX
 
@@ -505,11 +510,10 @@ BO_ 2452161040 rc_eps_gen_1: 8 Vector__XXX
  SG_ rc_eps_gen_1_temp_avg : 32|16@1+ (1,0) [0|65535] "dK" Vector__XXX
  SG_ rc_eps_gen_1_sysrstiv : 48|8@1+ (1,0) [0|256] "" Vector__XXX
 
-BO_ 2452161029 rc_eps_batt_6: 8 Vector__XXX
- SG_ rc_eps_batt_6_soc_min : 0|8@1+ (1,0) [0|255] "pct" Vector__XXX
- SG_ rc_eps_batt_6_soc_max : 8|8@1+ (1,0) [0|255] "pct" Vector__XXX
- SG_ rc_eps_batt_6_soc_avg : 16|8@1+ (1,0) [0|255] "pct" Vector__XXX
- SG_ rc_eps_batt_6_last_charge : 24|40@1+ (1,0) [0|1099511627775] "2^-8 seconds" Vector__XXX
+BO_ 2452161029 rc_eps_batt_6: 7 Vector__XXX
+ SG_ rc_eps_batt_6_status : 0|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ rc_eps_batt_6_ctrl : 8|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ rc_eps_batt_6_last_charge : 16|40@1+ (1,0) [0|1099511627775] "2^-8 seconds" Vector__XXX
 
 BO_ 2452161028 rc_eps_batt_5: 8 Vector__XXX
  SG_ rc_eps_batt_5_node_c_min : 0|16@1- (1,0) [-1000|1000] "dmA" Vector__XXX

--- a/teams/cdh/CAN/Experiments/codeGenOutput/canwrap.c
+++ b/teams/cdh/CAN/Experiments/codeGenOutput/canwrap.c
@@ -205,6 +205,27 @@ void setCANPacketRxCallback(void (*ReceiveCallbackArg)(CANPacket *packet)) {
 
 // AUTOGEN STUFF HERE
 
+void decoderc_eps_batt_7(CANPacket *input, rc_eps_batt_7 *output){
+    uint64_t *thePointer = (uint64_t *) input -> data;
+    reverseArray(input -> data, 0, 7);
+    const uint64_t fullData = *thePointer;
+    output -> rc_eps_batt_7_acc_charge_min = (uint16_t) (((fullData & ((uint64_t) 0xffff << 48)) >> 48));
+    output -> rc_eps_batt_7_acc_charge_max = (uint16_t) (((fullData & ((uint64_t) 0xffff << 32)) >> 32));
+    output -> rc_eps_batt_7_acc_charge_avg = (uint16_t) (((fullData & ((uint64_t) 0xffff << 16)) >> 16));
+}
+
+void encoderc_eps_batt_7(rc_eps_batt_7 *input, CANPacket *output){
+    output -> id = 304677466;
+    output -> length = 6;
+    uint64_t fullPacketData = 0x0000000000000000;
+    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_7_acc_charge_min))) & 0xffff) << 48;
+    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_7_acc_charge_max))) & 0xffff) << 32;
+    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_7_acc_charge_avg))) & 0xffff) << 16;
+    uint64_t *thePointer = (uint64_t *) (&(output -> data));
+    *thePointer = fullPacketData;
+    reverseArray((output->data), 0, 7);
+}
+
 void decoderc_adcs_estim_14(CANPacket *input, rc_adcs_estim_14 *output){
     uint64_t *thePointer = (uint64_t *) input -> data;
     reverseArray(input -> data, 0, 7);
@@ -2190,20 +2211,18 @@ void decoderc_eps_batt_6(CANPacket *input, rc_eps_batt_6 *output){
     uint64_t *thePointer = (uint64_t *) input -> data;
     reverseArray(input -> data, 0, 7);
     const uint64_t fullData = *thePointer;
-    output -> rc_eps_batt_6_soc_min = (uint8_t) (((fullData & ((uint64_t) 0xff << 56)) >> 56));
-    output -> rc_eps_batt_6_soc_max = (uint8_t) (((fullData & ((uint64_t) 0xff << 48)) >> 48));
-    output -> rc_eps_batt_6_soc_avg = (uint8_t) (((fullData & ((uint64_t) 0xff << 40)) >> 40));
-    output -> rc_eps_batt_6_last_charge = (uint64_t) (((fullData & ((uint64_t) 0xffffffffff))));
+    output -> rc_eps_batt_6_status = (uint8_t) (((fullData & ((uint64_t) 0xff << 56)) >> 56));
+    output -> rc_eps_batt_6_ctrl = (uint8_t) (((fullData & ((uint64_t) 0xff << 48)) >> 48));
+    output -> rc_eps_batt_6_last_charge = (uint64_t) (((fullData & ((uint64_t) 0xffffffffff << 8)) >> 8));
 }
 
 void encoderc_eps_batt_6(rc_eps_batt_6 *input, CANPacket *output){
     output -> id = 304677381;
-    output -> length = 8;
+    output -> length = 7;
     uint64_t fullPacketData = 0x0000000000000000;
-    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_6_soc_min))) & 0xff) << 56;
-    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_6_soc_max))) & 0xff) << 48;
-    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_6_soc_avg))) & 0xff) << 40;
-    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_6_last_charge))) & 0xffffffffff);
+    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_6_status))) & 0xff) << 56;
+    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_6_ctrl))) & 0xff) << 48;
+    fullPacketData |= (((uint64_t)((input -> rc_eps_batt_6_last_charge))) & 0xffffffffff) << 8;
     uint64_t *thePointer = (uint64_t *) (&(output -> data));
     *thePointer = fullPacketData;
     reverseArray((output->data), 0, 7);

--- a/teams/cdh/CAN/Experiments/codeGenOutput/canwrap.c
+++ b/teams/cdh/CAN/Experiments/codeGenOutput/canwrap.c
@@ -205,6 +205,120 @@ void setCANPacketRxCallback(void (*ReceiveCallbackArg)(CANPacket *packet)) {
 
 // AUTOGEN STUFF HERE
 
+void decoderc_adcs_estim_14(CANPacket *input, rc_adcs_estim_14 *output){
+    uint64_t *thePointer = (uint64_t *) input -> data;
+    reverseArray(input -> data, 0, 7);
+    const uint64_t fullData = *thePointer;
+    uint64_t temprc_adcs_estim_14_mag_z = (uint64_t) ((fullData & ((uint64_t) 0xffffffffffffffff)));
+output -> rc_adcs_estim_14_mag_z = (*((double *)(&(temprc_adcs_estim_14_mag_z))));
+}
+
+void encoderc_adcs_estim_14(rc_adcs_estim_14 *input, CANPacket *output){
+    output -> id = 304677465;
+    output -> length = 8;
+    uint64_t fullPacketData = 0x0000000000000000;
+    const double temprc_adcs_estim_14_mag_z = ((input -> rc_adcs_estim_14_mag_z));
+    fullPacketData |= ((uint64_t)(*((uint64_t *)(&(temprc_adcs_estim_14_mag_z)))));
+    uint64_t *thePointer = (uint64_t *) (&(output -> data));
+    *thePointer = fullPacketData;
+    reverseArray((output->data), 0, 7);
+}
+
+void decoderc_adcs_estim_13(CANPacket *input, rc_adcs_estim_13 *output){
+    uint64_t *thePointer = (uint64_t *) input -> data;
+    reverseArray(input -> data, 0, 7);
+    const uint64_t fullData = *thePointer;
+    uint64_t temprc_adcs_estim_13_mag_y = (uint64_t) ((fullData & ((uint64_t) 0xffffffffffffffff)));
+output -> rc_adcs_estim_13_mag_y = (*((double *)(&(temprc_adcs_estim_13_mag_y))));
+}
+
+void encoderc_adcs_estim_13(rc_adcs_estim_13 *input, CANPacket *output){
+    output -> id = 304677464;
+    output -> length = 8;
+    uint64_t fullPacketData = 0x0000000000000000;
+    const double temprc_adcs_estim_13_mag_y = ((input -> rc_adcs_estim_13_mag_y));
+    fullPacketData |= ((uint64_t)(*((uint64_t *)(&(temprc_adcs_estim_13_mag_y)))));
+    uint64_t *thePointer = (uint64_t *) (&(output -> data));
+    *thePointer = fullPacketData;
+    reverseArray((output->data), 0, 7);
+}
+
+void decoderc_adcs_estim_12(CANPacket *input, rc_adcs_estim_12 *output){
+    uint64_t *thePointer = (uint64_t *) input -> data;
+    reverseArray(input -> data, 0, 7);
+    const uint64_t fullData = *thePointer;
+    uint64_t temprc_adcs_estim_12_mag_x = (uint64_t) ((fullData & ((uint64_t) 0xffffffffffffffff)));
+output -> rc_adcs_estim_12_mag_x = (*((double *)(&(temprc_adcs_estim_12_mag_x))));
+}
+
+void encoderc_adcs_estim_12(rc_adcs_estim_12 *input, CANPacket *output){
+    output -> id = 304677463;
+    output -> length = 8;
+    uint64_t fullPacketData = 0x0000000000000000;
+    const double temprc_adcs_estim_12_mag_x = ((input -> rc_adcs_estim_12_mag_x));
+    fullPacketData |= ((uint64_t)(*((uint64_t *)(&(temprc_adcs_estim_12_mag_x)))));
+    uint64_t *thePointer = (uint64_t *) (&(output -> data));
+    *thePointer = fullPacketData;
+    reverseArray((output->data), 0, 7);
+}
+
+void decoderc_adcs_estim_11(CANPacket *input, rc_adcs_estim_11 *output){
+    uint64_t *thePointer = (uint64_t *) input -> data;
+    reverseArray(input -> data, 0, 7);
+    const uint64_t fullData = *thePointer;
+    uint64_t temprc_adcs_estim_11_sun_z = (uint64_t) ((fullData & ((uint64_t) 0xffffffffffffffff)));
+output -> rc_adcs_estim_11_sun_z = (*((double *)(&(temprc_adcs_estim_11_sun_z))));
+}
+
+void encoderc_adcs_estim_11(rc_adcs_estim_11 *input, CANPacket *output){
+    output -> id = 304677462;
+    output -> length = 8;
+    uint64_t fullPacketData = 0x0000000000000000;
+    const double temprc_adcs_estim_11_sun_z = ((input -> rc_adcs_estim_11_sun_z));
+    fullPacketData |= ((uint64_t)(*((uint64_t *)(&(temprc_adcs_estim_11_sun_z)))));
+    uint64_t *thePointer = (uint64_t *) (&(output -> data));
+    *thePointer = fullPacketData;
+    reverseArray((output->data), 0, 7);
+}
+
+void decoderc_adcs_estim_10(CANPacket *input, rc_adcs_estim_10 *output){
+    uint64_t *thePointer = (uint64_t *) input -> data;
+    reverseArray(input -> data, 0, 7);
+    const uint64_t fullData = *thePointer;
+    uint64_t temprc_adcs_estim_10_sun_y = (uint64_t) ((fullData & ((uint64_t) 0xffffffffffffffff)));
+output -> rc_adcs_estim_10_sun_y = (*((double *)(&(temprc_adcs_estim_10_sun_y))));
+}
+
+void encoderc_adcs_estim_10(rc_adcs_estim_10 *input, CANPacket *output){
+    output -> id = 304677461;
+    output -> length = 8;
+    uint64_t fullPacketData = 0x0000000000000000;
+    const double temprc_adcs_estim_10_sun_y = ((input -> rc_adcs_estim_10_sun_y));
+    fullPacketData |= ((uint64_t)(*((uint64_t *)(&(temprc_adcs_estim_10_sun_y)))));
+    uint64_t *thePointer = (uint64_t *) (&(output -> data));
+    *thePointer = fullPacketData;
+    reverseArray((output->data), 0, 7);
+}
+
+void decoderc_adcs_estim_9(CANPacket *input, rc_adcs_estim_9 *output){
+    uint64_t *thePointer = (uint64_t *) input -> data;
+    reverseArray(input -> data, 0, 7);
+    const uint64_t fullData = *thePointer;
+    uint64_t temprc_adcs_estim_9_sun_x = (uint64_t) ((fullData & ((uint64_t) 0xffffffffffffffff)));
+output -> rc_adcs_estim_9_sun_x = (*((double *)(&(temprc_adcs_estim_9_sun_x))));
+}
+
+void encoderc_adcs_estim_9(rc_adcs_estim_9 *input, CANPacket *output){
+    output -> id = 304677460;
+    output -> length = 8;
+    uint64_t fullPacketData = 0x0000000000000000;
+    const double temprc_adcs_estim_9_sun_x = ((input -> rc_adcs_estim_9_sun_x));
+    fullPacketData |= ((uint64_t)(*((uint64_t *)(&(temprc_adcs_estim_9_sun_x)))));
+    uint64_t *thePointer = (uint64_t *) (&(output -> data));
+    *thePointer = fullPacketData;
+    reverseArray((output->data), 0, 7);
+}
+
 void decoderc_eps_dist_16(CANPacket *input, rc_eps_dist_16 *output){
     uint64_t *thePointer = (uint64_t *) input -> data;
     reverseArray(input -> data, 0, 7);

--- a/teams/cdh/CAN/Experiments/codeGenOutput/canwrap.h
+++ b/teams/cdh/CAN/Experiments/codeGenOutput/canwrap.h
@@ -26,6 +26,12 @@
 
 // BEGIN GENERATOR MACROS
 
+#define CAN_ID_RC_ADCS_ESTIM_14 304677465
+#define CAN_ID_RC_ADCS_ESTIM_13 304677464
+#define CAN_ID_RC_ADCS_ESTIM_12 304677463
+#define CAN_ID_RC_ADCS_ESTIM_11 304677462
+#define CAN_ID_RC_ADCS_ESTIM_10 304677461
+#define CAN_ID_RC_ADCS_ESTIM_9 304677460
 #define CAN_ID_RC_EPS_DIST_16 304677458
 #define CAN_ID_RC_EPS_DIST_9 304677451
 #define CAN_ID_RC_EPS_DIST_7 304677449
@@ -232,6 +238,30 @@ void (*CANPacketReceived)(CANPacket *);
 uint8_t canSendPacket(CANPacket *packet);
 
 void setCANPacketRxCallback(void (*ReceiveCallbackArg)(CANPacket *packet));
+typedef struct rc_adcs_estim_14 {
+    double rc_adcs_estim_14_mag_z; //  (No Units)
+} rc_adcs_estim_14;
+
+typedef struct rc_adcs_estim_13 {
+    double rc_adcs_estim_13_mag_y; //  (No Units)
+} rc_adcs_estim_13;
+
+typedef struct rc_adcs_estim_12 {
+    double rc_adcs_estim_12_mag_x; //  (No Units)
+} rc_adcs_estim_12;
+
+typedef struct rc_adcs_estim_11 {
+    double rc_adcs_estim_11_sun_z; //  (No Units)
+} rc_adcs_estim_11;
+
+typedef struct rc_adcs_estim_10 {
+    double rc_adcs_estim_10_sun_y; //  (No Units)
+} rc_adcs_estim_10;
+
+typedef struct rc_adcs_estim_9 {
+    double rc_adcs_estim_9_sun_x; //  (No Units)
+} rc_adcs_estim_9;
+
 typedef struct rc_eps_dist_16 {
     uint8_t rc_eps_dist_16_ppt_state; //  (No Units)
     uint16_t rc_eps_dist_16_ppt_c_min; // mA
@@ -1036,6 +1066,24 @@ typedef struct grnd_epoch {
     uint8_t grnd_epoch_val_overflow; //  (No Units)
     uint32_t grnd_epoch_val; // 2^-8 s
 } grnd_epoch;
+
+void encoderc_adcs_estim_14(rc_adcs_estim_14 *input, CANPacket* output);
+void decoderc_adcs_estim_14(CANPacket *input, rc_adcs_estim_14 *output);
+
+void encoderc_adcs_estim_13(rc_adcs_estim_13 *input, CANPacket* output);
+void decoderc_adcs_estim_13(CANPacket *input, rc_adcs_estim_13 *output);
+
+void encoderc_adcs_estim_12(rc_adcs_estim_12 *input, CANPacket* output);
+void decoderc_adcs_estim_12(CANPacket *input, rc_adcs_estim_12 *output);
+
+void encoderc_adcs_estim_11(rc_adcs_estim_11 *input, CANPacket* output);
+void decoderc_adcs_estim_11(CANPacket *input, rc_adcs_estim_11 *output);
+
+void encoderc_adcs_estim_10(rc_adcs_estim_10 *input, CANPacket* output);
+void decoderc_adcs_estim_10(CANPacket *input, rc_adcs_estim_10 *output);
+
+void encoderc_adcs_estim_9(rc_adcs_estim_9 *input, CANPacket* output);
+void decoderc_adcs_estim_9(CANPacket *input, rc_adcs_estim_9 *output);
 
 void encoderc_eps_dist_16(rc_eps_dist_16 *input, CANPacket* output);
 void decoderc_eps_dist_16(CANPacket *input, rc_eps_dist_16 *output);

--- a/teams/cdh/CAN/Experiments/codeGenOutput/canwrap.h
+++ b/teams/cdh/CAN/Experiments/codeGenOutput/canwrap.h
@@ -26,6 +26,7 @@
 
 // BEGIN GENERATOR MACROS
 
+#define CAN_ID_RC_EPS_BATT_7 304677466
 #define CAN_ID_RC_ADCS_ESTIM_14 304677465
 #define CAN_ID_RC_ADCS_ESTIM_13 304677464
 #define CAN_ID_RC_ADCS_ESTIM_12 304677463
@@ -238,6 +239,12 @@ void (*CANPacketReceived)(CANPacket *);
 uint8_t canSendPacket(CANPacket *packet);
 
 void setCANPacketRxCallback(void (*ReceiveCallbackArg)(CANPacket *packet));
+typedef struct rc_eps_batt_7 {
+    uint16_t rc_eps_batt_7_acc_charge_min; // 22.588 mAh
+    uint16_t rc_eps_batt_7_acc_charge_max; // 22.588 mAh
+    uint16_t rc_eps_batt_7_acc_charge_avg; // 22.588 mAh
+} rc_eps_batt_7;
+
 typedef struct rc_adcs_estim_14 {
     double rc_adcs_estim_14_mag_z; //  (No Units)
 } rc_adcs_estim_14;
@@ -789,9 +796,8 @@ typedef struct rc_eps_gen_1 {
 } rc_eps_gen_1;
 
 typedef struct rc_eps_batt_6 {
-    uint8_t rc_eps_batt_6_soc_min; // pct
-    uint8_t rc_eps_batt_6_soc_max; // pct
-    uint8_t rc_eps_batt_6_soc_avg; // pct
+    uint8_t rc_eps_batt_6_status; //  (No Units)
+    uint8_t rc_eps_batt_6_ctrl; //  (No Units)
     uint64_t rc_eps_batt_6_last_charge; // 2^-8 seconds
 } rc_eps_batt_6;
 
@@ -1066,6 +1072,9 @@ typedef struct grnd_epoch {
     uint8_t grnd_epoch_val_overflow; //  (No Units)
     uint32_t grnd_epoch_val; // 2^-8 s
 } grnd_epoch;
+
+void encoderc_eps_batt_7(rc_eps_batt_7 *input, CANPacket* output);
+void decoderc_eps_batt_7(CANPacket *input, rc_eps_batt_7 *output);
 
 void encoderc_adcs_estim_14(rc_adcs_estim_14 *input, CANPacket* output);
 void decoderc_adcs_estim_14(CANPacket *input, rc_adcs_estim_14 *output);

--- a/teams/cdh/CAN/Experiments/codeGenOutput/test.c
+++ b/teams/cdh/CAN/Experiments/codeGenOutput/test.c
@@ -3,6 +3,36 @@
 #include <stddef.h>
 #include "interfaces/canwrap.h"
 void canBlast() { 
+	__delay_cycles(10000);	CANPacket rc_adcs_estim_14_packet = {0};
+	rc_adcs_estim_14 rc_adcs_estim_14_info = {0};
+	encoderc_adcs_estim_14(&rc_adcs_estim_14_info, &rc_adcs_estim_14_packet);
+	canSendPacket(&rc_adcs_estim_14_packet);
+
+	__delay_cycles(10000);	CANPacket rc_adcs_estim_13_packet = {0};
+	rc_adcs_estim_13 rc_adcs_estim_13_info = {0};
+	encoderc_adcs_estim_13(&rc_adcs_estim_13_info, &rc_adcs_estim_13_packet);
+	canSendPacket(&rc_adcs_estim_13_packet);
+
+	__delay_cycles(10000);	CANPacket rc_adcs_estim_12_packet = {0};
+	rc_adcs_estim_12 rc_adcs_estim_12_info = {0};
+	encoderc_adcs_estim_12(&rc_adcs_estim_12_info, &rc_adcs_estim_12_packet);
+	canSendPacket(&rc_adcs_estim_12_packet);
+
+	__delay_cycles(10000);	CANPacket rc_adcs_estim_11_packet = {0};
+	rc_adcs_estim_11 rc_adcs_estim_11_info = {0};
+	encoderc_adcs_estim_11(&rc_adcs_estim_11_info, &rc_adcs_estim_11_packet);
+	canSendPacket(&rc_adcs_estim_11_packet);
+
+	__delay_cycles(10000);	CANPacket rc_adcs_estim_10_packet = {0};
+	rc_adcs_estim_10 rc_adcs_estim_10_info = {0};
+	encoderc_adcs_estim_10(&rc_adcs_estim_10_info, &rc_adcs_estim_10_packet);
+	canSendPacket(&rc_adcs_estim_10_packet);
+
+	__delay_cycles(10000);	CANPacket rc_adcs_estim_9_packet = {0};
+	rc_adcs_estim_9 rc_adcs_estim_9_info = {0};
+	encoderc_adcs_estim_9(&rc_adcs_estim_9_info, &rc_adcs_estim_9_packet);
+	canSendPacket(&rc_adcs_estim_9_packet);
+
 	__delay_cycles(10000);	CANPacket rc_eps_dist_16_packet = {0};
 	rc_eps_dist_16 rc_eps_dist_16_info = {0};
 	encoderc_eps_dist_16(&rc_eps_dist_16_info, &rc_eps_dist_16_packet);

--- a/teams/cdh/CAN/Experiments/codeGenOutput/test.c
+++ b/teams/cdh/CAN/Experiments/codeGenOutput/test.c
@@ -3,6 +3,11 @@
 #include <stddef.h>
 #include "interfaces/canwrap.h"
 void canBlast() { 
+	__delay_cycles(10000);	CANPacket rc_eps_batt_7_packet = {0};
+	rc_eps_batt_7 rc_eps_batt_7_info = {0};
+	encoderc_eps_batt_7(&rc_eps_batt_7_info, &rc_eps_batt_7_packet);
+	canSendPacket(&rc_eps_batt_7_packet);
+
 	__delay_cycles(10000);	CANPacket rc_adcs_estim_14_packet = {0};
 	rc_adcs_estim_14 rc_adcs_estim_14_info = {0};
 	encoderc_adcs_estim_14(&rc_adcs_estim_14_info, &rc_adcs_estim_14_packet);


### PR DESCRIPTION
The bdot MSP now needs the separate readings from both magnetometers of sensor proc. This just copies the existing magnetometer packet.